### PR TITLE
Use cl-str

### DIFF
--- a/app.lisp
+++ b/app.lisp
@@ -1,4 +1,4 @@
-(ql:quickload '(:ningle :djula :dexador :cl-json))
+(ql:quickload '(:ningle :djula :dexador :cl-json :str))
 (djula:add-template-directory  #P"templates/")
 (defparameter *template-registry* (make-hash-table :test 'equal))
 
@@ -32,21 +32,25 @@
       #'(lambda (params)
 	  (print params)
 	  (let* ((page (cdr (assoc "page" params :test #'string=)))
-		 (beers (cl-json:decode-json-from-string (dex:get (concatenate 'string "https://api.punkapi.com/v2/beers?per_page=24&page=" page)))))
+		 (beers (cl-json:decode-json-from-string 
+			 (dex:get (str:concat "https://api.punkapi.com/v2/beers?per_page=24&page=" 
+				              page)))))
 	    ;; (print page)
       (render #P"_more-beer.html" (list :beers beers :page (increment-page page))))))
 
 ;; GET /beer/:id
 (setf (ningle:route *app* "/beer/:id")
       #'(lambda (params)
-	  (let ((beer (cl-json:decode-json-from-string (dex:get (concatenate 'string "https://api.punkapi.com/v2/beers/" (cdr (assoc :id params)))))))
+	  (let ((beer (cl-json:decode-json-from-string 
+		        (dex:get (str:concat "https://api.punkapi.com/v2/beers/" 
+				             (cdr (assoc :id params)))))))
 	    (print beer)
 	    (render #P"show.html" (list :beer (car beer))))))
 
 ;; GET /random
 (setf (ningle:route *app* "/random")
       #'(lambda (params)
-	  (let ((beer (cl-json:decode-json-from-string (dex:get "https://api.punkapi.com/v2/beers/random" ))))
+	  (let ((beer (cl-json:decode-json-from-string (dex:get "https://api.punkapi.com/v2/beers/random"))))
 	    (render #P"show.html" (list :beer (car beer))))))
 
 ;; GET /glossary
@@ -56,7 +60,8 @@
 (setf (ningle:route *app* "/search" :method :POST)
       #'(lambda (params)
           (let* ((query (cdr (assoc "query" params :test #'string=)))
-                (beers (cl-json:decode-json-from-string (dex:get (concatenate 'string "https://api.punkapi.com/v2/beers?beer_name=" query)))))
+                (beers (cl-json:decode-json-from-string (dex:get (str:concat "https://api.punkapi.com/v2/beers?beer_name=" 
+					                                     query)))))
             (print beers)
             (render #P"_search-results.html" (list :beers beers)))))
 


### PR DESCRIPTION
This PR uses [str:concat](https://github.com/vindarel/cl-str/blob/master/str.lisp#L171) for nicer string concatenation syntax as it doesn't need the `'string` symbol/type argument.

Also adds some respacing.

wdyt?